### PR TITLE
Job queue support and performance improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 afwiki-latest-pages-articles.xml
 *.bz2
+*.log
+node_modules

--- a/README.markdown
+++ b/README.markdown
@@ -55,3 +55,22 @@ db.wikipedia.findOne({title:"Toronto"}).categories
 ##Same for the English wikipedia:
 the english wikipedia will work under the same process, but
 the download will take an afternoon, and the loading/parsing a couple hours. The en wikipedia dump is a 4gb download and becomes a pretty legit mongo collection uncompressed. It's something like 40gb, but mongo can do it... You can do it!
+
+##Load wikipedia much faster
+there is yet much faster way (even x10) to import all pages into mongodb but a little more complex. it requires redis installed on your computer and running worker in separate process
+````bash
+# install redis on ubuntu
+sudo apt-get install redis-server
+
+# clone wikipedia-to-mongodb
+git clone git@github.com:spencermountain/wikipedia-to-mongodb.git
+
+#load pages into job queue
+node index.js ./afwiki-latest-pages-articles.xml.bz2 -w
+
+# start processing jobs (parsing articles and saving to mongodb) on all CPU's
+node worker.js
+
+# you can preview processing jobs in kue dashboard (localhost:3000)
+node node_modules/kue/bin/kue-dashboard -p 3000
+````

--- a/README.markdown
+++ b/README.markdown
@@ -65,7 +65,7 @@ sudo apt-get install redis-server
 # clone wikipedia-to-mongodb
 git clone git@github.com:spencermountain/wikipedia-to-mongodb.git
 
-#load pages into job queue
+#load pages into job queue (there as additional param -w)
 node index.js ./afwiki-latest-pages-articles.xml.bz2 -w
 
 # start processing jobs (parsing articles and saving to mongodb) on all CPU's

--- a/config/queue.js
+++ b/config/queue.js
@@ -1,6 +1,7 @@
 var kue = require('kue')
 var queue = kue.createQueue({
   prefix: 'q',
+  jobEvents: false,
   redis: {
     port: 6379,
     host: 'localhost'

--- a/config/queue.js
+++ b/config/queue.js
@@ -1,0 +1,11 @@
+var kue = require('kue')
+var queue = kue.createQueue({
+  prefix: 'q',
+  redis: {
+    port: 6379,
+    host: 'localhost'
+    //auth: ''
+  }
+});
+
+module.exports = queue;

--- a/helper.js
+++ b/helper.js
@@ -12,4 +12,3 @@ exports.processScript = function(options, cb) {
     return cb()
   })
 }
-

--- a/helper.js
+++ b/helper.js
@@ -1,0 +1,15 @@
+var wikipedia = require('wtf_wikipedia')
+
+exports.processScript = function(options, cb) {
+  var data = wikipedia.parse(options.script)
+  data.title = options.title
+  options.collection.insert(data, function(e) {
+    if (e) {
+      console.log(e)
+      return cb(e)
+    }
+
+    return cb()
+  })
+}
+

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "commander": "^2.9.0",
     "kue": "^0.11.0",
     "mongodb": "^2.1.18",
-    "mongoskin": "^2.1.0",
     "unbzip2-stream": "^1.0.9",
     "wtf_wikipedia": "^0.3.2",
     "xml-stream": "^0.4.5"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Spencer Kelly <spencermountain@gmail.com> (http://spencermounta.in)",
   "name": "wikipedia-to-mongodb",
   "description": "stream a wikipedia dump into mongo",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "repository": {
     "type": "git",
     "url": "git://github.com/spencermountain/wikipedia-to-mongodb.git"
@@ -15,7 +15,10 @@
     "node = 0.10.33"
   ],
   "dependencies": {
+    "commander": "^2.9.0",
+    "kue": "^0.11.0",
     "mongodb": "^2.1.18",
+    "mongoskin": "^2.1.0",
     "unbzip2-stream": "^1.0.9",
     "wtf_wikipedia": "^0.3.2",
     "xml-stream": "^0.4.5"

--- a/worker.js
+++ b/worker.js
@@ -1,0 +1,30 @@
+// run job queue dashboard to see statistics
+// node node_modules/kue/bin/kue-dashboard -p 3050
+
+var util = require('util');
+var cluster = require('cluster')
+var clusterWorkerSize = require('os').cpus().length;
+var concurrency = 3;
+var helper = require('./helper')
+var queue = require('./config/queue');
+var mongo = require('mongoskin');
+
+if (cluster.isMaster) {
+  for (var i = 0; i < clusterWorkerSize; i++) {
+    cluster.fork();
+  }
+} else {
+  // url should be improved by configuration or cli arguments
+  var url = 'mongodb://localhost:27017/wikipedia_queue';
+  var db = mongo.db(url, {native_parser:true});
+  var collection = db.collection('wikipedia');
+  queue.process('article', concurrency, function(job, done){
+    var url = job.data.url;
+    var data = job.data
+    data.collection = collection;
+    helper.processScript(data, function(err, res) {
+      //console.log('processed');
+      done(err, res)
+    })
+  });
+}


### PR DESCRIPTION
Hi, 

I kept current API as it is and added support for kue https://github.com/Automattic/kue (redis job queue)
The performance increased even x10 with using workers.

Usage:

```bash
$ sudo apt-get install redis-server
$ git clone git@github.com:spencermountain/wikipedia-to-mongodb.git

# (adding all articles into job queue,  -w parameter)
$ node index.js ./afwiki-latest-pages-articles.xml.bz2 -w

# (that is for processing jobs)
$ node worker.js

# (this is only for seeing the job queue dashboard)
$ node node_modules/kue/bin/kue-dashboard -p 3000
```

I was considering too https://github.com/kissjs/node-mongoskin for synchronous mongodb connection but had some memory leak problems and didn't want to much changes 

I will be happy to get review and feel free to make any changes which will simplify that