### PR TITLE
Skips the delay for insertion during early articles, and scales it after that.

### DIFF
--- a/bin/wp2mongo.js
+++ b/bin/wp2mongo.js
@@ -11,6 +11,8 @@ let parseArgs = function() {
     .option('--skip_disambig', 'if true, skips-over disambiguation pages')
     .option('--skip_first <n>', 'ignore the first n pages', parseInt)
     .option('--verbose', 'print each article title to the console')
+	.option('--threshold <n>', 'number of articles to parse before introducing a delay every 30 seconds for the MongoDB queue to catch up; defaults to 5,000,000')
+	.option('--start_delay <n>', 'initial delay (when the threshold is reached) in milliseconds; defaults to 1,000, and increases in proportion to the number of articles parsed')
     .parse(process.argv)
 
   //grab the wiki file

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,8 @@ const doPage = require('./page');
 const main = function(options, callback) {
   options.skip_first = options.skip_first || 0
   options.verbose = options.verbose || false
+  options.threshold = options.threshold || 5000000
+  options.start_delay = options.start_delay || 1000
   callback = callback || function() {};
 
   if (options.skip_first > 0) {
@@ -40,7 +42,9 @@ const main = function(options, callback) {
     xml._preserveAll = true; //keep newlines
 
     let i = 1;
-    let last = 0
+    let last = 0;
+	let pauseThreshold = options.threshold
+	let startDelay = options.start_delay
 
     //this is our logger
     console.log('\n\n --- starting xml parsing --\n')
@@ -52,12 +56,15 @@ const main = function(options, callback) {
 
     //this lets us a clear the queue
     let holdUp = setInterval(function() {
-      console.log('\n\n-- taking a quick break..--')
-      xml.pause();
-      setTimeout(function() {
-        xml.resume();
-        console.log('.. ok back. \n')
-      }, 3000)
+	  if (i > pauseThreshold) {
+        console.log('\n\n-- taking a quick break..--')
+		let duration = Math.round((i / pauseThreshold) * startDelay);
+        xml.pause();
+        setTimeout(function() {
+          xml.resume();
+          console.log('.. ok back. \n')
+        }, duration)
+	  }
     }, 30000);
 
     xml.on('endElement: page', function(page) {

--- a/src/index.js
+++ b/src/index.js
@@ -43,7 +43,7 @@ const main = function(options, callback) {
 
     let i = 1;
     let last = 0;
-	let pauseThreshold = options.threshold
+	let pauseThreshold = options.threshold;
 	let startDelay = options.start_delay
 
     //this is our logger


### PR DESCRIPTION
Since I started running it on my machine, I added CLI options to set the delay threshold (number of articles to parse before starting the delays) and the initial delay length.  Those options should work, but I haven't had a chance to test them.