### PR TITLE
Prevents pausing while handling skipped articles, and bug fixes

### DIFF
--- a/bin/wp2mongo.js
+++ b/bin/wp2mongo.js
@@ -9,10 +9,10 @@ let parseArgs = function() {
     .option('-plain, --plaintext', 'if true, store plaintext wikipedia articles')
     .option('--skip_redirects', 'if true, skips-over pages that are redirects')
     .option('--skip_disambig', 'if true, skips-over disambiguation pages')
-    .option('--skip_first <n>', 'ignore the first n pages', parseInt)
+    .option('--skip_first <n>', 'ignore the first n pages, and do not pause while handling those pages', parseInt)
     .option('--verbose', 'print each article title to the console')
-	.option('--threshold <n>', 'number of articles to parse before introducing a delay every 30 seconds for the MongoDB queue to catch up; defaults to 5,000,000')
-	.option('--start_delay <n>', 'initial delay (when the threshold is reached) in milliseconds; defaults to 1,000, and increases in proportion to the number of articles parsed')
+	.option('--threshold <n>', 'number of articles to parse before introducing a pause every 30 seconds for the MongoDB queue to catch up; defaults to 5,000,000', parseInt)
+	.option('--start_delay <n>', 'initial pause (when the threshold is reached) in milliseconds; defaults to 1,000, and increases in proportion to the number of articles parsed', parseInt)
     .parse(process.argv)
 
   //grab the wiki file

--- a/src/index.js
+++ b/src/index.js
@@ -43,6 +43,7 @@ const main = function(options, callback) {
 
     let i = 1;
     let last = 0;
+	let skipFirst = options.skip_first;
 	let pauseThreshold = options.threshold;
 	let startDelay = options.start_delay
 
@@ -56,7 +57,7 @@ const main = function(options, callback) {
 
     //this lets us a clear the queue
     let holdUp = setInterval(function() {
-	  if (i > pauseThreshold) {
+	  if (i > pauseThreshold && i > skipFirst) {
         console.log('\n\n-- taking a quick break..--')
 		let duration = Math.round((i / pauseThreshold) * startDelay);
         xml.pause();
@@ -69,7 +70,7 @@ const main = function(options, callback) {
 
     xml.on('endElement: page', function(page) {
       i += 1
-      if (i > options.skip_first) {
+      if (i > skipFirst) {
         doPage(page, options, queue, function() {})
       }
     });


### PR DESCRIPTION
There's no need to pause while skipping articles.  Also, I left the "parseInt" out of the CLI for the pause options.